### PR TITLE
refactor: modernize layout and improve responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,27 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rental Tools</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ["Inter", "sans-serif"],
+              display: ["Poppins", "sans-serif"],
+            },
+          },
+        },
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body>
+  <body class="font-sans text-neutral-700">
     <div id="root"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/App.js
+++ b/src/App.js
@@ -13,15 +13,13 @@ import {
   Star,
   Plus,
   Search,
-  LogIn,
-  LogOut,
-  User,
   Settings,
   ShieldCheck,
   DollarSign,
   ImagePlus,
   Building2,
   Check,
+  Menu,
 } from "lucide-react";
 
 // ---------------- Minimal UI component stubs ----------------
@@ -232,13 +230,13 @@ const allListings = [
 // ---------------- Main App ----------------
 export default function ToolShareApp() {
   const [role, setRole] = useState("customer");
-  const [logged, setLogged] = useState(false);
   const [query, setQuery] = useState("");
   const [activeCategory, setActiveCategory] = useState("all");
   // Ensure a consistent shape for the date range to avoid runtime/build issues.
   const [dateRange, setDateRange] = useState({ from: undefined, to: undefined });
   const [showCreate, setShowCreate] = useState(false);
   const [showPlans, setShowPlans] = useState(false);
+  const [showMobileFilters, setShowMobileFilters] = useState(false);
 
   const filtered = useMemo(() => filterListings(allListings, query, activeCategory), [activeCategory, query]);
 
@@ -247,8 +245,6 @@ export default function ToolShareApp() {
       <TopNav
         role={role}
         setRole={setRole}
-        logged={logged}
-        setLogged={setLogged}
         onCreate={() => setShowCreate(true)}
         onOpenPlans={() => setShowPlans(true)}
       />
@@ -258,15 +254,15 @@ export default function ToolShareApp() {
         <div className="absolute inset-0 bg-gradient-to-b from-orange-50 to-white" />
         <div className="relative mx-auto max-w-7xl px-6 py-16 md:py-24">
           <div className="grid gap-10 md:grid-cols-2 md:items-center">
-            <div>
+            <div className="text-center md:text-left">
               <Badge className="bg-orange-500 hover:bg-orange-600 text-white mb-4">New - Premium spotlight</Badge>
-              <h1 className="text-4xl md:text-5xl font-bold tracking-tight">
-                Rent <span className="text-orange-600">tools & machinery</span> like booking a stay
+              <h1 className="font-display text-5xl md:text-6xl font-bold tracking-tight">
+                Rent <span className="text-orange-600">tools &amp; machinery</span> like booking a stay
               </h1>
-              <p className="mt-4 text-neutral-600 text-lg">
+              <p className="mt-4 text-neutral-600 text-lg md:pr-12 max-w-xl mx-auto md:mx-0">
                 A marketplace inspired by Airbnb - clean, fast and built for pros. Browse categories, compare prices per day, and book with insurance.
               </p>
-              <div className="mt-6 flex flex-col sm:flex-row gap-3">
+              <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center md:justify-start">
                 <Button className="bg-orange-600 hover:bg-orange-700" size="lg" onClick={() => setShowPlans(true)}>
                   <Star className="mr-2 h-4 w-4" />
                   Upgrade business plan
@@ -296,9 +292,9 @@ export default function ToolShareApp() {
               </div>
 
               {/* Search Bar */}
-              <div className="mt-8 rounded-2xl border p-3 shadow-sm">
-                <div className="flex flex-col md:flex-row items-stretch gap-3">
-                  <div className="flex-1 flex items-center gap-2">
+              <div className="mt-10">
+                <div className="hidden md:flex items-center rounded-full bg-white shadow-lg divide-x">
+                  <div className="flex items-center gap-2 px-5 flex-1">
                     <Search className="h-5 w-5 text-neutral-500" />
                     <Input
                       placeholder='Search tools, e.g. "mini excavator"'
@@ -307,15 +303,15 @@ export default function ToolShareApp() {
                       className="border-none focus-visible:ring-0"
                     />
                   </div>
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2 px-5">
                     <MapPin className="h-5 w-5 text-neutral-500" />
-                    <Input className="w-48" placeholder="City or ZIP" />
+                    <Input className="w-40 border-none focus-visible:ring-0" placeholder="City or ZIP" />
                   </div>
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2 px-5">
                     <CalendarDays className="h-5 w-5 text-neutral-500" />
                     <Sheet>
                       <SheetTrigger asChild>
-                        <Button variant="outline" className="min-w-[180px] justify-between">
+                        <Button variant="ghost" className="justify-between px-0">
                           {dateRange.from && dateRange.to ? (
                             <span>
                               {dateRange.from.toLocaleDateString()} - {dateRange.to.toLocaleDateString()}
@@ -333,9 +329,7 @@ export default function ToolShareApp() {
                           <Calendar
                             mode="range"
                             selected={dateRange}
-                            onSelect={(r) =>
-                              setDateRange(r || { from: undefined, to: undefined })
-                            }
+                            onSelect={(r) => setDateRange(r || { from: undefined, to: undefined })}
                             numberOfMonths={2}
                             className="rounded-md border"
                           />
@@ -343,7 +337,71 @@ export default function ToolShareApp() {
                       </SheetContent>
                     </Sheet>
                   </div>
-                  <Button className="bg-orange-600 hover:bg-orange-700">Search</Button>
+                  <Button className="ml-4 rounded-full bg-orange-600 hover:bg-orange-700 flex items-center gap-2 px-6">
+                    <Search className="h-4 w-4" /> Search
+                  </Button>
+                </div>
+                <div className="md:hidden">
+                  {showMobileFilters ? (
+                    <div className="space-y-3 rounded-3xl border p-4 shadow-lg bg-white">
+                      <div className="flex items-center gap-2">
+                        <Search className="h-5 w-5 text-neutral-500" />
+                        <Input
+                          placeholder='Search tools, e.g. "mini excavator"'
+                          value={query}
+                          onChange={(e) => setQuery(e.target.value)}
+                          className="border-none focus-visible:ring-0"
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <MapPin className="h-5 w-5 text-neutral-500" />
+                        <Input className="flex-1 border-none focus-visible:ring-0" placeholder="City or ZIP" />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <CalendarDays className="h-5 w-5 text-neutral-500" />
+                        <Sheet>
+                          <SheetTrigger asChild>
+                            <Button variant="outline" className="flex-1 justify-between">
+                              {dateRange.from && dateRange.to ? (
+                                <span>
+                                  {dateRange.from.toLocaleDateString()} - {dateRange.to.toLocaleDateString()}
+                                </span>
+                              ) : (
+                                <span>Select dates</span>
+                              )}
+                            </Button>
+                          </SheetTrigger>
+                          <SheetContent side="bottom" className="h-[70vh]">
+                            <SheetHeader>
+                              <SheetTitle>Select your rental window</SheetTitle>
+                            </SheetHeader>
+                            <div className="py-4">
+                              <Calendar
+                                mode="range"
+                                selected={dateRange}
+                                onSelect={(r) => setDateRange(r || { from: undefined, to: undefined })}
+                                numberOfMonths={2}
+                                className="rounded-md border"
+                              />
+                            </div>
+                          </SheetContent>
+                        </Sheet>
+                      </div>
+                      <Button
+                        className="w-full rounded-full bg-orange-600 hover:bg-orange-700 flex items-center justify-center gap-2"
+                        onClick={() => setShowMobileFilters(false)}
+                      >
+                        <Search className="h-4 w-4" /> Search
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      className="w-full rounded-full bg-orange-600 hover:bg-orange-700 flex items-center justify-center gap-2"
+                      onClick={() => setShowMobileFilters(true)}
+                    >
+                      <Search className="h-5 w-5" /> Filters
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>
@@ -351,7 +409,7 @@ export default function ToolShareApp() {
             <div className="relative">
               <div className="aspect-[4/3] w-full overflow-hidden rounded-3xl border shadow-lg">
                 <img
-                  src="https://images.unsplash.com/photo-1508387027616-4d1f0d57e3a6?q=80&w=1600&auto=format&fit=crop"
+                  src="https://images.unsplash.com/photo-1591508513884-1e39fa00a811?q=80&w=1600&auto=format&fit=crop"
                   alt="Tools hero"
                   className="h-full w-full object-cover"
                 />
@@ -375,7 +433,7 @@ export default function ToolShareApp() {
       <Separator />
 
       {/* Category Pills */}
-      <section className="mx-auto max-w-7xl px-6 py-8">
+      <section className="mx-auto max-w-7xl px-6 py-12">
         <ScrollArea className="w-full whitespace-nowrap">
           <div className="flex gap-3">
             {categories.map(({ key, label, icon: Icon }) => (
@@ -396,7 +454,7 @@ export default function ToolShareApp() {
       </section>
 
       {/* Premium Spotlight */}
-      <section className="mx-auto max-w-7xl px-6 pb-2">
+      <section className="mx-auto max-w-7xl px-6 py-12">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-xl font-semibold">Premium spotlight</h2>
           <Button variant="ghost" className="text-orange-600 hover:text-orange-700" onClick={() => setShowPlans(true)}>
@@ -411,7 +469,7 @@ export default function ToolShareApp() {
       </section>
 
       {/* All Listings */}
-      <section className="mx-auto max-w-7xl px-6 py-10">
+      <section className="mx-auto max-w-7xl px-6 py-12">
         <h2 className="text-xl font-semibold mb-4">Explore tools</h2>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((l) => (
@@ -443,7 +501,7 @@ export default function ToolShareApp() {
             <TabsContent value="overview">
               <Card>
                 <CardHeader>
-                  <CardTitle>Welcome {logged ? "MaxTools Pro" : "Business"}</CardTitle>
+                  <CardTitle>Welcome Business</CardTitle>
                   <CardDescription>Manage your tools, availability, pricing and bookings.</CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-4 md:grid-cols-3">
@@ -518,24 +576,48 @@ export default function ToolShareApp() {
 }
 
 // ---------------- Components ----------------
-function TopNav({ role, setRole, logged, setLogged, onCreate, onOpenPlans }) {
+const navLinks = [
+  { label: "How it works", href: "#" },
+  { label: "Categories", href: "#" },
+  { label: "Safety", href: "#" },
+  { label: "Support", href: "#" },
+];
+
+function TopNav({ role, setRole, onCreate, onOpenPlans }) {
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-white/80 backdrop-blur">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
+    <header className="sticky top-0 z-50 w-full border-b bg-neutral-50/80 backdrop-blur">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-2 text-sm">
         <div className="flex items-center gap-3">
-          <div className="h-9 w-9 grid place-content-center rounded-xl bg-orange-600 text-white font-bold">TS</div>
+          <div className="h-8 w-8 grid place-content-center rounded-lg bg-orange-600 text-white font-bold">TS</div>
           <div className="font-semibold">ToolShare</div>
           <Badge variant="secondary" className="ml-2">Beta</Badge>
         </div>
-        <nav className="hidden md:flex items-center gap-6 text-sm">
-          <a className="hover:text-orange-600" href="#">How it works</a>
-          <a className="hover:text-orange-600" href="#">Categories</a>
-          <a className="hover:text-orange-600" href="#">Safety</a>
-          <a className="hover:text-orange-600" href="#">Support</a>
+        <nav className="hidden md:flex items-center gap-6">
+          {navLinks.map((l) => (
+            <a key={l.label} className="hover:text-orange-600" href={l.href}>
+              {l.label}
+            </a>
+          ))}
         </nav>
         <div className="flex items-center gap-2">
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon" className="md:hidden">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-64">
+              <nav className="mt-4 flex flex-col gap-4 text-sm">
+                {navLinks.map((l) => (
+                  <a key={l.label} href={l.href}>
+                    {l.label}
+                  </a>
+                ))}
+              </nav>
+            </SheetContent>
+          </Sheet>
           <div className="hidden sm:flex items-center gap-2 pr-3 mr-3 border-r">
-            <Label htmlFor="role-switch" className="mr-2 text-sm">Business mode</Label>
+            <Label htmlFor="role-switch" className="mr-2">Business mode</Label>
             <Switch id="role-switch" checked={role === "business"} onCheckedChange={(v) => setRole(v ? "business" : "customer")} />
           </div>
           {role === "business" && (
@@ -543,52 +625,11 @@ function TopNav({ role, setRole, logged, setLogged, onCreate, onOpenPlans }) {
               <Plus className="mr-2 h-4 w-4" /> New listing
             </Button>
           )}
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="ghost" className="gap-2">
-                <User className="h-4 w-4" /> {logged ? "Account" : "Sign in"}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>{logged ? "Your account" : "Welcome back"}</DialogTitle>
-                <DialogDescription>
-                  {logged ? "Manage your profile and preferences." : "Sign in to book or manage your listings."}
-                </DialogDescription>
-              </DialogHeader>
-              {logged ? (
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Avatar>
-                      <AvatarImage src="https://i.pravatar.cc/100?img=67" />
-                      <AvatarFallback>MX</AvatarFallback>
-                    </Avatar>
-                    <div>
-                      <div className="font-medium">MaxTools Pro</div>
-                      <div className="text-xs text-neutral-500">Business - Premium</div>
-                    </div>
-                  </div>
-                  <Button variant="outline" onClick={() => setLogged(false)}>
-                    <LogOut className="mr-2 h-4 w-4" /> Sign out
-                  </Button>
-                </div>
-              ) : (
-                <div className="grid gap-3">
-                  <Input placeholder="Email" />
-                  <Input placeholder="Password" type="password" />
-                  <Button className="bg-orange-600 hover:bg-orange-700" onClick={() => setLogged(true)}>
-                    <LogIn className="mr-2 h-4 w-4" /> Sign in
-                  </Button>
-                  <Button variant="outline">Create account</Button>
-                </div>
-              )}
-            </DialogContent>
-          </Dialog>
-          <Button className="bg-orange-600 hover:bg-orange-700" onClick={onOpenPlans}>
+          <Button className="bg-orange-600 hover:bg-orange-700 rounded-full px-4" onClick={onOpenPlans}>
             <Star className="mr-2 h-4 w-4" /> Premium
           </Button>
           <Button variant="ghost" size="icon" className="ml-1">
-            <Settings className="h-4 w-4" />
+            <Settings className="h-5 w-5" />
           </Button>
         </div>
       </div>
@@ -600,7 +641,7 @@ function ListingCard({ listing, premium, showManage }) {
   return (
     <Card className="overflow-hidden group hover:shadow-lg transition-shadow">
       <div className="relative">
-        <img src={listing.img} alt={listing.title} className="h-48 w-full object-cover" />
+        <img src={listing.img} alt={listing.title} className="h-40 w-full object-cover md:h-52" />
         {premium && (
           <Badge className="absolute left-3 top-3 bg-orange-600 hover:bg-orange-700">Premium</Badge>
         )}
@@ -626,12 +667,12 @@ function ListingCard({ listing, premium, showManage }) {
           <span className="text-sm text-neutral-600">{listing.business.name}</span>
         </div>
       </CardContent>
-      <CardFooter className="flex items-center justify-between p-4 pt-0">
-        <Button variant="outline" className="gap-2"><CalendarDays className="h-4 w-4" /> Check availability</Button>
+      <CardFooter className="flex items-center gap-2 justify-between p-4 pt-0">
+        <Button variant="outline" className="gap-2 flex-1"><CalendarDays className="h-4 w-4" /> Check availability</Button>
         {showManage ? (
-          <Button className="bg-orange-600 hover:bg-orange-700">Manage</Button>
+          <Button className="bg-orange-600 hover:bg-orange-700 flex-1">Manage</Button>
         ) : (
-          <Button className="bg-orange-600 hover:bg-orange-700">Book now</Button>
+          <Button className="bg-orange-600 hover:bg-orange-700 flex-1">Book now</Button>
         )}
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Summary
- remove header login dialog and account state
- deduplicate navigation links with shared array for desktop and mobile menus
- extract navigation links constant for reuse across header menus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdd21eef8832a94685ec1ce244d0e